### PR TITLE
[Fix] Purge orphaned achievement criteria progress at startup

### DIFF
--- a/src/game/WorldHandlers/AchievementMgr.cpp
+++ b/src/game/WorldHandlers/AchievementMgr.cpp
@@ -3072,6 +3072,44 @@ void AchievementGlobalMgr::LoadCompletedAchievements()
     sLog.outString(">> Loaded " SIZEFMTD " realm completed achievements.", m_allCompletedAchievements.size());
 }
 
+void AchievementGlobalMgr::CleanupOrphanedCriteriaProgress()
+{
+    QueryResult* result = CharacterDatabase.Query("SELECT DISTINCT `criteria` FROM `character_achievement_progress`");
+
+    if (!result)
+    {
+        BarGoLink bar(1);
+        bar.step();
+
+        sLog.outString();
+        sLog.outString(">> Removed 0 orphaned criteria data. DB table `character_achievement_progress` is empty.");
+        return;
+    }
+
+    uint32 count = 0;
+    BarGoLink bar(result->GetRowCount());
+    do
+    {
+        bar.step();
+        Field* fields = result->Fetch();
+
+        uint32 criteria_id = fields[0].GetUInt32();
+        if (!sAchievementCriteriaStore.LookupEntry(criteria_id))
+        {
+            // we will remove nonexistent criteria for all characters
+            sLog.outError("Nonexistent achievement criteria %u data removed from table `character_achievement_progress`.", criteria_id);
+            CharacterDatabase.PExecute("DELETE FROM `character_achievement_progress` WHERE `criteria` = %u", criteria_id);
+            ++count;
+        }
+    }
+    while (result->NextRow());
+
+    delete result;
+
+    sLog.outString();
+    sLog.outString(">> Removed %u orphaned criteria data from table `character_achievement_progress`.", count);
+}
+
 void AchievementGlobalMgr::LoadRewards()
 {
     m_achievementRewards.clear();                           // need for reload case

--- a/src/game/WorldHandlers/AchievementMgr.h
+++ b/src/game/WorldHandlers/AchievementMgr.h
@@ -329,6 +329,8 @@ class AchievementGlobalMgr
         void LoadAchievementCriteriaRequirements();
         void LoadAchievementReferenceList();
         void LoadCompletedAchievements();
+        /// Remove `character_achievement_progress` rows whose criteria no longer exists in DBC
+        void CleanupOrphanedCriteriaProgress();
         void LoadRewards();
         void LoadRewardLocales();
 

--- a/src/game/WorldHandlers/World.cpp
+++ b/src/game/WorldHandlers/World.cpp
@@ -1379,6 +1379,7 @@ void World::SetInitialWorldSettings()
     sAchievementMgr.LoadRewards();
     sAchievementMgr.LoadRewardLocales();
     sAchievementMgr.LoadCompletedAchievements();
+    sAchievementMgr.CleanupOrphanedCriteriaProgress();
     sLog.outString(">>> Achievements loaded");
     sLog.outString();
 


### PR DESCRIPTION
Paired with mangosthree/server#291 and mangostwo/server#238 (same fix across the Cata/WotLK forks).

Adds a global, unconditional startup purge of orphaned `character_achievement_progress` rows (criteria no longer present in DBC), mirroring the existing completed-achievement purge.

Startup already drops orphaned **completed** achievements in `LoadCompletedAchievements()` (a nonexistent `achievement` id is deleted for all characters). Progress rows had no equivalent: an invalid `criteria` was removed only lazily, per-character, when an affected character logs in (`AchievementMgr::LoadFromDB`). Orphaned progress rows belonging to characters that never log in therefore persisted indefinitely.

New `AchievementGlobalMgr::CleanupOrphanedCriteriaProgress()` runs once at startup, right after `LoadCompletedAchievements()` (criteria/DBC stores are already loaded by then): `SELECT DISTINCT criteria`, validate each against `sAchievementCriteriaStore`, delete invalid ones for all characters. No-op when the table is empty or nothing is orphaned; same log wording as the existing per-character purge. Code-only, no schema change.

Note (separate, not addressed here): `CharacterDatabaseCleaner` — which had the only other global progress purge — never runs on any core, because nothing ever sets `cleaning_flags` in `saved_variables` (schema-default 0, only ever read and reset). That's a latent design question (what should set the flags) worth its own discussion.
